### PR TITLE
Fix/cleanup project

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -47,12 +47,6 @@ export default function RootLayout({
           crossOrigin="anonymous"
           referrerPolicy="no-referrer"
         />
-        {process.env.NODE_ENV === "development" && (
-          <script
-            crossOrigin="anonymous"
-            src="//unpkg.com/react-scan/dist/auto.global.js"
-          />
-        )}
       </head>
       <body
         className={`${geistSans.variable} ${geistMono.variable} bg-grid flex min-h-screen flex-col bg-gray-100`}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,6 +5,7 @@ import QuotationForm from "@/components/QuotationForm";
 import QuotationPreview from "@/components/QuotationPreview";
 import Button from "@/components/prototype/Button";
 import runAxeCheck from "@/utils/axe";
+import dayjs from "dayjs";
 
 type EDIT_TYPES = "edit" | "preview";
 
@@ -76,8 +77,7 @@ export default function Home() {
 
       <footer className="sticky bottom-0 z-10 w-full space-x-2 bg-white py-4 text-center text-xs text-gray-700">
         <span>
-          &copy; {new Date().getFullYear()} Quotation Form For. All rights
-          reserved.
+          &copy; {dayjs().year()} Quotation Form For. All rights reserved.
         </span>
         <span className="mt-2 text-xs text-gray-700">
           All Icons by&nbsp;

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,11 +1,12 @@
 "use client";
 
-import { useState } from "react";
+import { use, useState } from "react";
 import QuotationForm from "@/components/QuotationForm";
 import QuotationPreview from "@/components/QuotationPreview";
 import Button from "@/components/prototype/Button";
 import runAxeCheck from "@/utils/axe";
 import dayjs from "dayjs";
+import { useEffect } from "react";
 
 type EDIT_TYPES = "edit" | "preview";
 
@@ -17,10 +18,18 @@ export default function Home() {
     preview: <QuotationPreview />,
   };
 
-  const handleTabChange = (tab: EDIT_TYPES) => {
+  useEffect(() => {
+    handleRunAxeCheck();
+  }, []);
+
+  const handleRunAxeCheck = () => {
     if (process.env.NODE_ENV === "development") {
       runAxeCheck();
     }
+  };
+
+  const handleTabChange = (tab: EDIT_TYPES) => {
+    handleRunAxeCheck();
     setActiveTab(tab);
   };
 
@@ -41,6 +50,8 @@ export default function Home() {
                 onClick={() => handleTabChange("edit")}
                 variant={activeTab === "edit" ? "primary" : "secondary"}
                 className="gap-2"
+                id="edit-button"
+                aria-label="編輯報價單"
               >
                 <i className="fa-solid fa-pen-to-square"></i>
                 編輯報價單
@@ -49,6 +60,8 @@ export default function Home() {
                 onClick={() => handleTabChange("preview")}
                 variant={activeTab === "preview" ? "primary" : "secondary"}
                 className="gap-2"
+                id="preview-button"
+                aria-label="預覽報價單"
               >
                 <i className="fa-solid fa-eye"></i>
                 預覽報價單

--- a/components/QuotationForm/BaseInfo/index.tsx
+++ b/components/QuotationForm/BaseInfo/index.tsx
@@ -12,18 +12,21 @@ export default function BaseInfo({
         <Input
           label="報價單編號"
           value={quotation.id}
+          placeholder="請輸入報價單編號..."
           onChange={(value) => updateQuotation("id", value)}
         />
         <Input
           label="報價日期"
           type="date"
           value={quotation.date}
+          placeholder="請輸入報價日期..."
           onChange={(value) => updateQuotation("date", value)}
         />
         <Input
           label="有效期至"
           type="date"
           value={quotation.validUntil}
+          placeholder="請輸入有效期至..."
           onChange={(value) => updateQuotation("validUntil", value)}
         />
       </div>

--- a/components/QuotationForm/ClientInfo/index.tsx
+++ b/components/QuotationForm/ClientInfo/index.tsx
@@ -12,23 +12,27 @@ export default function ClientInfo({
         <Input
           label="名稱"
           value={quotation.customerName}
+          placeholder="請輸入名稱..."
           onChange={(value) => updateQuotation("customerName", value)}
         />
         <Input
           label="電話"
           type="tel"
           value={quotation.customerPhone}
+          placeholder="請輸入電話..."
           onChange={(value) => updateQuotation("customerPhone", value)}
         />
         <Input
           label="信箱"
           type="email"
           value={quotation.customerEmail}
+          placeholder="請輸入信箱..."
           onChange={(value) => updateQuotation("customerEmail", value)}
         />
         <Input
           label="地址"
           value={quotation.customerAddress}
+          placeholder="請輸入地址..."
           onChange={(value) => updateQuotation("customerAddress", value)}
         />
       </div>

--- a/components/QuotationForm/CompanyInfo/index.tsx
+++ b/components/QuotationForm/CompanyInfo/index.tsx
@@ -12,12 +12,14 @@ export default function CompanyInfo({
         <Input
           label="接案人"
           value={quotation.freelancer}
+          placeholder="請輸入接案人..."
           onChange={(value) => updateQuotation("freelancer", value)}
         />
         <Input
           label="信箱"
           type="email"
           value={quotation.companyEmail}
+          placeholder="請輸入信箱..."
           onChange={(value) => updateQuotation("companyEmail", value)}
         />
       </div>

--- a/components/QuotationForm/ItemList/SortableItem/index.tsx
+++ b/components/QuotationForm/ItemList/SortableItem/index.tsx
@@ -45,6 +45,7 @@ export default function SortableItem({
             label={`項目 ${index + 1} `}
             value={item.name}
             size="sm"
+            placeholder="請輸入項目..."
             onChange={(value) => updateItem(item.id, "name", value)}
           />
         </div>
@@ -55,6 +56,7 @@ export default function SortableItem({
           step={1}
           min={0}
           value={item.hourlyRate}
+          placeholder="請輸入時薪..."
           onChange={(value) => updateItem(item.id, "hourlyRate", value)}
         />
         <Input
@@ -64,6 +66,7 @@ export default function SortableItem({
           min={0}
           size="sm"
           value={item.hours}
+          placeholder="請輸入時數..."
           onChange={(value) => updateItem(item.id, "hours", value)}
         />
         <div className="text-mx flex items-center justify-end pt-6 text-right font-medium text-gray-700">

--- a/components/QuotationPreview/QuotationNotes/index.tsx
+++ b/components/QuotationPreview/QuotationNotes/index.tsx
@@ -7,7 +7,7 @@ const notes = [
 
 export default function QuotationNotes() {
   return (
-    <div className="space-y-1 divide-gray-200 text-xs text-gray-600">
+    <div className="space-y-1 divide-gray-200 text-xs text-gray-600 pt-2">
       {notes.map((note, idx) => (
         <p key={idx}>
           {idx + 1}. {note}

--- a/components/QuotationPreview/index.tsx
+++ b/components/QuotationPreview/index.tsx
@@ -52,28 +52,10 @@ export default function QuotationPreview() {
 
   return (
     <div className="mx-auto max-w-4xl">
-      <div className="relative">
-        <div className="absolute left-[-8rem]">{/* 輸出紀錄 */}</div>
-        <div className="absolute right-0 md:right-[-8rem]">
-          <div className="hidden md:flex">
-            <Button
-              onClick={handleExportPDF}
-              variant="warning"
-              className="gap-1"
-            >
-              <i className="fa-solid fa-download"></i> 匯出 PDF
-            </Button>
-          </div>
-          <div className="flex md:hidden">
-            <Button
-              onClick={handleExportPDF}
-              variant="warning"
-              className="gap-1"
-            >
-              <i className="fa-solid fa-download"></i> 匯出 PDF
-            </Button>
-          </div>
-        </div>
+      <div className="flex justify-end mb-4">
+        <Button onClick={handleExportPDF} variant="warning" className="gap-2">
+          <i className="fa-solid fa-download"></i> 匯出 PDF
+        </Button>
       </div>
 
       <div
@@ -98,7 +80,7 @@ export default function QuotationPreview() {
         {mainWorkContent && (
           <div className="mb-4">
             <h3 className="mb-3 border-b pb-2 text-lg font-semibold text-gray-800">
-              備註
+              主要工作內容
             </h3>
             <p className="whitespace-pre-wrap text-gray-700">
               {mainWorkContent}
@@ -109,7 +91,7 @@ export default function QuotationPreview() {
         {techStack && (
           <div className="mb-4">
             <h3 className="mb-3 border-b pb-2 text-lg font-semibold text-gray-800">
-              備註
+              技術要求
             </h3>
             <p className="whitespace-pre-wrap text-gray-700">{techStack}</p>
           </div>


### PR DESCRIPTION
# 無障礙（Accessibility, a11y）優化與元件重構

## 主要修正內容

- **元件重構與程式碼清理**
  - 重構多個元件（如 QuotationPreview、QuotationNotes、layout、page 等），優化結構與可維護性。

- **表單元件 label 與 placeholder**
  - Input 與 Textarea 元件自動產生唯一 id，label 的 htmlFor 正確對應 input/textarea 的 id。
  - 為多個 Input 元件補上 placeholder，提升可用性。

- **無障礙細節修正**
  - 解決 nested-interactive（互動元素巢狀）、heading order（標題階層）、button name（SVG-only 按鈕加 aria-label）、label 等無障礙問題。
  - 通過 axe、Lighthouse 等自動化檢查。

- **其他**
  - 修正頁尾年份顯示（dayjs year）。
  - 其他小幅度優化與修正。
